### PR TITLE
Fix aggregator filter loading and ticker parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,8 +34,7 @@ async def main():
     dp.include_router(history.router)
 
     session = aiohttp.ClientSession()
-    queue = asyncio.Queue()
-    asyncio.create_task(start_aggregator(queue, session, bot))
+    asyncio.create_task(start_aggregator(session, bot))
 
     async def handle_webhook(request):
         update = await request.json()

--- a/services/filter_engine.py
+++ b/services/filter_engine.py
@@ -1,5 +1,9 @@
+import json
+import logging
+
+
 def apply_filters(tickers, filters_file):
-    import logging
+    """Load user filters from ``filters_file`` and apply them to ``tickers``."""
     try:
         with open(filters_file, "r") as f:
             filters = json.load(f)


### PR DESCRIPTION
## Summary
- load filters file directly inside filter engine
- simplify aggregator usage of filters
- map Bybit tickers to include buy, sell and volume
- drop unused `queue` parameter in aggregator

## Testing
- `python -m py_compile main.py services/aggregator.py services/filter_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_6854249276e483278f1253589ff0a0ff