### PR TITLE
Adjust volume parsing logic

### DIFF
--- a/handlers/filter_engine.py
+++ b/handlers/filter_engine.py
@@ -11,8 +11,10 @@ def apply_filters(tickers, filters_file):
     for chat_id, f in filters.items():
         buy_limit = float(f.get("buy_price", 0))
         sell_limit = float(f.get("sell_price", 999999))
-        # "volume" represents the trade size metric used by the aggregator
-        # (best bid size or 24h volume). Compare user limit to this value.
+        # "volume" represents the trade size derived from the best bid
+        # (bid1Price * bid1Size). If that is not available, the aggregator
+        # falls back to the ticker's 24h volume. User limits compare
+        # against this value.
         vol_limit = float(f.get("volume", 100))
         exchange = f.get("exchange", "bybit")
 

--- a/services/aggregator.py
+++ b/services/aggregator.py
@@ -19,15 +19,14 @@ async def start_aggregator(session: ClientSession, bot):
                         symbol = item.get("symbol", "")
                         buy = float(item.get("bid1Price", item.get("lastPrice", 0)))
                         sell = float(item.get("ask1Price", item.get("lastPrice", 0)))
-                        # Bybit returns turnover24h which represents trade value in
-                        # USD. For single trades we want the actual amount of
-                        # coins traded, so try to use volume24h if present.
-                        volume = float(item.get("volume24h", 0))
-                        if not volume:
-                            # Fall back to the size of the best bid if provided
-                            bid_price = float(item.get("bid1Price", 0))
-                            bid_size = float(item.get("bid1Size", 0))
+                        # Derive volume from the best bid if possible; fall back
+                        # to Bybit's 24h volume metric otherwise.
+                        bid_price = float(item.get("bid1Price", 0))
+                        bid_size = float(item.get("bid1Size", 0))
+                        if bid_price and bid_size:
                             volume = bid_price * bid_size
+                        else:
+                            volume = float(item.get("volume24h", 0))
                         price = float(item.get("lastPrice", 0))
                         tickers.append({
                             "symbol": symbol,

--- a/services/filter_engine.py
+++ b/services/filter_engine.py
@@ -14,9 +14,9 @@ def apply_filters(tickers, filters_file):
     for chat_id, f in filters.items():
         buy_limit = float(f.get("buy_price", 0))
         sell_limit = float(f.get("sell_price", 999999))
-        # "volume" here refers to the amount traded for the best bid (or
-        # 24h volume if available in the ticker). User limits are compared to
-        # this value.
+        # "volume" represents the trade size taken from the best bid when
+        # available (bid1Price * bid1Size). If that information is missing,
+        # the aggregator falls back to the ticker's 24h volume.
         vol_limit = float(f.get("volume", 100))
         exchange = f.get("exchange", "bybit")
 


### PR DESCRIPTION
## Summary
- calculate ticker volume from best bid when possible
- clarify volume comment in filter engines

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685429ccdf9083279e298482fe64e3c8