### PR TITLE
Improve logging in aggregator

### DIFF
--- a/services/aggregator.py
+++ b/services/aggregator.py
@@ -36,7 +36,10 @@ async def start_aggregator(session: ClientSession, bot):
                             "price": price,
                             "sell_price": sell,
                         })
-                    except Exception:
+                    except Exception as e:
+                        logging.debug(
+                            "Failed to parse ticker item %s: %s", item, e
+                        )
                         continue
                 logging.info(f"🟢 Bybit вернул {len(tickers)} тикеров")
 


### PR DESCRIPTION
## Summary
- log parsing errors inside the aggregator loop using `logging.debug`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542bf58c3083279c8efdcdffc3882e