### PR TITLE
Centralize FILTERS_FILE constant

### DIFF
--- a/handlers/arbitrage_dynamic.py
+++ b/handlers/arbitrage_dynamic.py
@@ -1,10 +1,9 @@
 from aiogram import Router, F
 from aiogram.types import CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 import json
+from config import FILTERS_FILE
 
 router = Router()
-
-FILTERS_FILE = "filters.json"
 
 @router.callback_query(F.data == "arbitrage")
 async def show_arbitrage(call: CallbackQuery):

--- a/services/const.py
+++ b/services/const.py
@@ -1,1 +1,0 @@
-FILTERS_FILE = "filters.json"


### PR DESCRIPTION
## Summary
- keep `FILTERS_FILE` only in `config.py`
- import it in `arbitrage_dynamic.py`
- drop obsolete `services/const.py`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68542bf59a9083279294c0a1b9278c14