### PR TITLE
Remove .env and provide example

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-
-API_TOKEN=8131766932:AAFPfxgWtoY7fejhp5dofLsz0q7701L4GAI
-WEBHOOK_URL=https://arbitpro-bot-official.onrender.com/webhook
-PORT=10000
-

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+API_TOKEN=your-telegram-bot-token
+WEBHOOK_URL=https://example.com/webhook
+PORT=10000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+__pycache__/
+venv/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -17,19 +17,18 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3. **Configure environment variables** (or create a `.env` file):
+3. **Configure environment variables** by copying `.env.example` to `.env` and
+   filling in your real values:
+
+```bash
+cp .env.example .env
+```
+
+Environment variables in `.env`:
 
 - `API_TOKEN` – Telegram bot token
-- `WEBHOOK_URL` – public HTTPS URL for Telegram webhooks (`https://<your-host>/webhook`)
+- `WEBHOOK_URL` – public HTTPS URL for Telegram webhooks
 - `PORT` – port to run the web server (default: `10000`)
-
-Example `.env`:
-
-```env
-API_TOKEN=<your-token>
-WEBHOOK_URL=https://example.com/webhook
-PORT=10000
-```
 
 4. **Run the bot**:
 


### PR DESCRIPTION
## Summary
- stop tracking `.env` and ignore it
- provide `.env.example` for new users
- explain copying `.env.example` in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543312a79483279c8d806f067a622d