### PR TITLE
Add conftest for pytest imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock
+
+from services import aggregator
+from services.aggregator import start_aggregator
+
+
+class FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    async def json(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeSession:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, url):
+        return FakeResp(self._data)
+
+
+@pytest.mark.asyncio
+async def test_start_aggregator_sends_notification(monkeypatch, tmp_path):
+    filters = {"10": {"buy_price": 100, "sell_price": 120, "volume": 10}}
+    fpath = tmp_path / "filters.json"
+    fpath.write_text(json.dumps(filters))
+
+    api_data = {
+        "result": {
+            "list": [
+                {
+                    "symbol": "ABC",
+                    "bid1Price": "90",
+                    "ask1Price": "130",
+                    "bid1Size": "0.1",
+                    "lastPrice": "90"
+                }
+            ]
+        }
+    }
+
+    session = FakeSession(api_data)
+    bot = AsyncMock()
+
+    monkeypatch.setattr(aggregator, "FILTERS_FILE", str(fpath))
+
+    async def fake_sleep(_):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(aggregator.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_aggregator(session, bot)
+
+    bot.send_message.assert_called_once()
+    args, _ = bot.send_message.call_args
+    assert args[0] == "10"
+    assert "ABC" in args[1]

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -1,0 +1,21 @@
+import json
+from services.filter_engine import apply_filters
+
+
+def test_apply_filters_respects_limits(tmp_path):
+    filters = {"1": {"buy_price": 100, "sell_price": 500, "volume": 10}}
+    fpath = tmp_path / "filters.json"
+    fpath.write_text(json.dumps(filters))
+
+    tickers = [
+        {"symbol": "AAA", "price": 90, "sell_price": 520, "volume": 5},
+        {"symbol": "BBB", "price": 90, "sell_price": 480, "volume": 5},
+        {"symbol": "CCC", "price": 110, "sell_price": 520, "volume": 5},
+        {"symbol": "DDD", "price": 90, "sell_price": 520, "volume": 15},
+    ]
+
+    result = apply_filters(tickers, fpath)
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["symbol"] == "AAA"
+    assert entry["chat_id"] == "1"


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding a `conftest.py`
- previous commit included unit test for `apply_filters` and integration test for `start_aggregator`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854331353f483279e64c6531603fbb8