### PR TITLE
Add test dependencies documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The bot will start the aggregator and listen for Telegram updates on the specifi
 
 ## Running Tests
 
+Tests require the `aiohttp`, `aiogram`, and `pytest-asyncio` packages. Install them with `pip install -r requirements-dev.txt`.
+
 Execute the test suite with:
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+aiohttp
+aiogram
+pytest-asyncio


### PR DESCRIPTION
## Summary
- update README with additional requirements for tests
- list packages used for testing in requirements-dev.txt

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: building wheel for aiohttp)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68553c85ef7c83279993e03219cb6e78