### PR TITLE
Add aiogram stubs and tests

### DIFF
--- a/aiogram/filters.py
+++ b/aiogram/filters.py
@@ -1,0 +1,15 @@
+class CommandStart:
+    """Placeholder for aiogram.filters.CommandStart"""
+
+    def __init__(self, command: str = "start"):
+        self.command = command
+
+
+class Command:
+    """Placeholder for aiogram.filters.Command"""
+
+    def __init__(self, command: str):
+        self.command = command
+
+
+__all__ = ["CommandStart", "Command"]

--- a/aiogram/fsm/context.py
+++ b/aiogram/fsm/context.py
@@ -1,0 +1,22 @@
+class FSMContext:
+    """Simplified in-memory FSM context placeholder."""
+
+    def __init__(self):
+        self.state = None
+        self.data = {}
+
+    async def set_state(self, state):
+        self.state = state
+
+    async def update_data(self, **kwargs):
+        self.data.update(kwargs)
+
+    async def get_data(self):
+        return dict(self.data)
+
+    async def clear(self):
+        self.state = None
+        self.data.clear()
+
+
+__all__ = ["FSMContext"]

--- a/aiogram/fsm/state.py
+++ b/aiogram/fsm/state.py
@@ -1,0 +1,11 @@
+class State:
+    """Placeholder state representation."""
+    pass
+
+
+class StatesGroup:
+    """Placeholder for grouping states."""
+    pass
+
+
+__all__ = ["State", "StatesGroup"]

--- a/tests/test_aiogram_stubs.py
+++ b/tests/test_aiogram_stubs.py
@@ -1,0 +1,27 @@
+import importlib
+import pytest
+
+
+def test_filters_import():
+    module = importlib.import_module('aiogram.filters')
+    assert hasattr(module, 'CommandStart')
+    assert hasattr(module, 'Command')
+
+
+@pytest.mark.asyncio
+async def test_fsm_context():
+    from aiogram.fsm.context import FSMContext
+
+    ctx = FSMContext()
+    await ctx.set_state('state1')
+    await ctx.update_data(foo='bar')
+    data = await ctx.get_data()
+    assert data == {'foo': 'bar'}
+    await ctx.clear()
+    assert await ctx.get_data() == {}
+
+
+def test_fsm_state_import():
+    module = importlib.import_module('aiogram.fsm.state')
+    assert hasattr(module, 'State')
+    assert hasattr(module, 'StatesGroup')


### PR DESCRIPTION
## Summary
- provide minimal `CommandStart` and `Command` stubs
- implement simple `FSMContext`
- add dummy `State` and `StatesGroup`
- test that aiogram stubs import and basic context works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855451ccab4832793ae37de492af1c4